### PR TITLE
feat: allow detail messages that contain [pub] in error responses

### DIFF
--- a/src/packages/server/responder/utils/data-for.js
+++ b/src/packages/server/responder/utils/data-for.js
@@ -24,8 +24,8 @@ export default function dataFor(
     errData.title = title;
   }
 
-  if (err && env.isDevelopment()) {
-    errData.detail = err.message;
+  if (err && (env.isDevelopment() || /\[public\]/gi.test(err.message))) {
+    errData.detail = err.message.replace(/\[public\]/gi, '');
   }
 
   return {


### PR DESCRIPTION
After https://github.com/postlight/lux/pull/713 was merged, this made it impossible to return any meaningful error messages when desired.  This PR adds a rudimentary way to specifically allow a message detail by including `[public]` in the message.

When the `[public]` tag is found in the message, the error.detail value is set and the `[public]` string is removed.
