### PR TITLE
fix: the `count` method did not account for whereRaw and whereBetween

### DIFF
--- a/src/packages/database/query/index.js
+++ b/src/packages/database/query/index.js
@@ -298,7 +298,7 @@ class Query<+T: any> extends Promise {
   }
 
   count(): Query<number> {
-    const validName = /^(where(Not)?(In)?)$/g;
+    const validName = /^(where(((Not)?(In)?)|(Raw)|(Between)))$/g;
 
     Object.assign(this, {
       shouldCount: true,


### PR DESCRIPTION
The `count` method in the query class did not account for whereRaw and whereBetween queries setting incorrect pagination numbers (total) in the JSONAPI response. This broke, for example, using a scope with a `whereRaw` on a `super.index(req, res)` call by using the total amount of records for setting pagination metrics.

<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue or RFC this addresses.

Contributing Guide: https://github.com/postlight/lux/blob/master/CONTRIBUTING.md
-->
