### PR TITLE
fix: don't update belongsTo relationships for new records

### DIFF
--- a/src/packages/database/relationship/utils/update-relationship.js
+++ b/src/packages/database/relationship/utils/update-relationship.js
@@ -115,7 +115,7 @@ function updateBelongsTo({
 
     Reflect.set(record, opts.foreignKey, foreignKeyValue);
 
-    if (inverseOpts && inverseOpts.type === 'hasOne') {
+    if (inverseOpts && inverseOpts.type === 'hasOne' && !record.isNew) {
       return [
         record.constructor
           .table()

--- a/src/packages/database/relationship/utils/update-relationship.js
+++ b/src/packages/database/relationship/utils/update-relationship.js
@@ -115,7 +115,7 @@ function updateBelongsTo({
 
     Reflect.set(record, opts.foreignKey, foreignKeyValue);
 
-    if (inverseOpts && inverseOpts.type === 'hasOne' && !record.isNew) {
+    if (inverseOpts && inverseOpts.type === 'hasOne') {
       return [
         record.constructor
           .table()


### PR DESCRIPTION
   NOTE: side-effect is that duplicate ID's might occur when DB does not have a UNIQUE constraint on the FK

<!--
Thanks for submitting a pull request!

In order to get this change merged in a timely manner, please provide a short
description, review requirements, and a link to the issue or RFC this addresses.

Contributing Guide: https://github.com/postlight/lux/blob/master/CONTRIBUTING.md
-->
